### PR TITLE
Stop using `TARGET_OS_SIMULATOR` flag

### DIFF
--- a/Sources/SimpleCamera.swift
+++ b/Sources/SimpleCamera.swift
@@ -755,7 +755,8 @@ public final class SimpleCamera: NSObject, SimpleCameraInterface {
     private var isConfigured: Bool = false
 
     private func configure() { // この configure 実行でカメラの許可ダイアログが出る
-        if isConfigured || (TARGET_OS_SIMULATOR != 0) {
+#if !targetEnvironment(simulator)
+        if isConfigured {
             return
         }
         defer {
@@ -899,10 +900,12 @@ public final class SimpleCamera: NSObject, SimpleCameraInterface {
         sessionQueue.sync {
             addObservers()
         }
+#endif
     }
 
     private func tearDown() {
-        if !isConfigured || (TARGET_OS_SIMULATOR != 0) {
+#if !targetEnvironment(simulator)
+        if !isConfigured {
             return
         }
 
@@ -928,6 +931,7 @@ public final class SimpleCamera: NSObject, SimpleCameraInterface {
             audioDeviceInput = nil
             isConfigured = false
         }
+#endif
     }
 
     // MARK: KVO and Notifications

--- a/Sources/SimpleCamera.swift
+++ b/Sources/SimpleCamera.swift
@@ -755,7 +755,7 @@ public final class SimpleCamera: NSObject, SimpleCameraInterface {
     private var isConfigured: Bool = false
 
     private func configure() { // この configure 実行でカメラの許可ダイアログが出る
-        if isConfigured || (TARGET_OS_SIMULATOR != 0) {
+        if isConfigured || targetEnvironment(simulator) {
             return
         }
         defer {
@@ -902,7 +902,7 @@ public final class SimpleCamera: NSObject, SimpleCameraInterface {
     }
 
     private func tearDown() {
-        if !isConfigured || (TARGET_OS_SIMULATOR != 0) {
+        if !isConfigured || targetEnvironment(simulator) {
             return
         }
 


### PR DESCRIPTION
Xcode 16.3
```
Cannot find 'TARGET_OS_SIMULATOR' in scope
```